### PR TITLE
(New Swag Opportunity) Adding alpaca swag in list

### DIFF
--- a/src/list.json
+++ b/src/list.json
@@ -3,6 +3,14 @@
   "list": {
     "A": [
       {
+        "organization": "Alpaca",
+        "org_url": "https://alpaca.markets/",
+        "tags": ["Tshirt"],
+        "description": "Alpaca announces its participating in hacktoberfet 2021 and rewarding cool t-shirt. If you’re one of the first 20 participants to submit one or more successfully merged pull requests to our open source projects and any contributions to the community-built SDKs, such as Java and R ones, as well as anything that uses Alpaca API, you’ll receive an Alpaca T-shirt.",
+        "no_of_prs": 1,
+        "link": "https://alpaca.markets/blog/hacktoberfest-2021-celebrate-open-source-with-alpaca/"
+      },
+      {
         "organization": "Appwrite",
         "org_url": "https://appwrite.io/",
         "tags": ["Tshirt", "Stickers", "Mug"],


### PR DESCRIPTION
New Swag Opportunity, adding alpaca swag to list. Here is [blog link](https://alpaca.markets/blog/hacktoberfest-2021-celebrate-open-source-with-alpaca/) of Alpaca announcing it participation in hacktoberfest 2021.
@monizb Please review it asap.