### PR TITLE
Remove duplicate description tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,6 @@
   <link rel="icon" href="https://raw.githubusercontent.com/github/explore/f47aef15a1c8f22b6fc5c7abf615a918f1322cd6/topics/hacktoberfest/hacktoberfest.png" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Hacktoberfest 2021 Swag List" />
   <meta name="image" content="https://user-images.githubusercontent.com/46259712/192037191-3d1737bf-f4cb-4d9a-a63b-cdde95c47b4f.png" />
   <meta name="description" content="Hacktoberfest 2022 Swag List" />
   <meta property="og:image" content=”%PUBLIC_URL%/wallpaper.png />


### PR DESCRIPTION
I have removed the duplicate `meta description` tag that had 2021 in the text.