### PR TITLE
corrected info for HackSquad swag

### DIFF
--- a/src/list.json
+++ b/src/list.json
@@ -97,7 +97,7 @@
         "organization": "HackSquad",
         "org_url": "https://www.hacksquad.dev/",
         "tags": ["Tshirt", "Hoodie", "Mug", "Bag"],
-        "description": "Register to the HackSquad using your GitHub, Join a team or get assigned to a random team. Each day we will calculate every team member approved PR and sum them all together. By the end of the event, the top 300 teams will win awesome swag!",
+        "description": "Register to the HackSquad using your GitHub, Join a team or get assigned to a random team. Each day we will calculate every team member approved PR and sum them all together. By the end of the event, the top 60 teams will win awesome swag!",
         "no_of_prs": 1,
         "link": "https://dev.to/novu/hacksquad-2022-contribute-meet-participate-and-win-swag-3b18"
       },


### PR DESCRIPTION
Fixes #191 

Corrected the info about HackSquad swag for Hacktoberfest 2022.